### PR TITLE
ENH: Create a Panel Widget

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source =
+    typhon 
+[report]
+omit =
+    #tests
+    */tests/*
+    *test*
+    #versioning
+    .*version.*
+    *_version.py

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--- Provide a general summary of the issue in the Title above -->
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--- Provide a general summary of your changes in the Title above -->
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Where Has This Been Documented?
+<!--  Include where the changes made have been documented. -->
+<!--  This can simply be  a comment in the code or updating a docstring -->
+
+<!--
+## Screenshots (if appropriate):
+-->

--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,0 +1,16 @@
+doc-warnings : true
+test-warnings : false
+strictness: medium
+max-line-length : 80
+autodetect: true
+ignore-paths:
+   - docs
+   - typhon/__init__.py
+ignore-patterns:
+    - versioneer.py
+    - typhon/_version.py
+python-targets:
+    - 3
+pylint:
+    disable:
+        - protected-access

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,60 @@
+language: python
+sudo: required
+dist: trusty
+matrix:
+  include:
+     - python: 3.6
+
+services:
+  - docker
+
+before_install:
+  - git clone https://github.com/NSLS-II/nsls2-ci --branch master --single-branch ~/ci_scripts
+  - export DOCKER0_IP=$(/sbin/ifconfig docker0 |grep 'inet addr' | sed -e 's/.*addr:\([^ ]*\).*/\1/')
+  - export EPICS_CA_ADDR_LIST=$( echo $DOCKER0_IP | sed -e 's/^\([0-9]\+\)\.\([0-9]\+\)\..*$/\1.\2.255.255/' )
+  - export EPICS_CA_AUTO_ADDR_LIST="no"
+  - export EPICS_CA_MAX_ARRAY_BYTES=10000000
+  - export DOCKERIMAGE="klauer/epics-docker"
+  - export EPICS_BASE=/usr/lib/epics
+  - mkdir /tmp/data
+  - perl --version
+  - docker pull ${DOCKERIMAGE}
+  - docker images
+  - docker run -d -p $DOCKER0_IP:7000-9000:5064/tcp -v /tmp/data:/data ${DOCKERIMAGE}
+  - docker ps -a
+  - ip addr
+install:
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda install conda-build anaconda-client
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  #Grab all dependencies
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig coverage pip ophyd pyqt=5 pytest -c lightsource2-tag -c conda-forge
+  #Launch Conda environment
+  - source activate test-environment
+  - pip install codecov
+  - pip install -r requirements.txt
+  #Install
+  - python setup.py install
+  #Setup some path environment variables for epics
+  - export PATH=$PATH:$EPICS_BASE/bin/$EPICS_HOST_ARCH
+  - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$EPICS_BASE/lib/$EPICS_HOST_ARCH"
+  - echo "PATH=$PATH"
+
+before_script:
+    #Taken from docs.travis-ci.com/user/gui-and-headless-browsers
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+
+script:
+  - coverage run run_tests.py
+  - coverage report -m

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/slaclab/pydm.git
+git+https://github.com/NSLS-II/ophyd.git

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import sys
+import pytest
+
+if __name__ == '__main__':
+    #Show output results from every test function
+    #Show the message output for skipped and expected failures
+    args = ['-v', '-vrxs']
+
+    #Add extra arguments
+    if len(sys.argv) >1:
+        args.extend(sys.argv[1:])
+
+    print('pytest arguments: {}'.format(args))
+
+    sys.exit(pytest.main(args))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,76 @@
+############
+# Standard #
+############
+import logging
+from functools import wraps
+############
+# External #
+############
+import pytest
+from pydm import PyDMApplication
+###########
+# Package #
+###########
+
+logger = logging.getLogger(__name__)
+
+#Global testing variables
+show_widgets = False
+application  = None
+
+
+def pytest_addoption(parser):
+    parser.addoption("--log", action="store", default="INFO",
+                     help="Set the level of the log")
+    parser.addoption("--logfile", action="store", default=None,
+                     help="Write the log output to specified file path")
+    parser.addoption("--show", action="store_true", default=False,
+                     help="Show the widgets produced by each test")
+
+#Create a fixture to automatically instantiate logging setup
+@pytest.fixture(scope='session', autouse=True)
+def _set_level(pytestconfig):
+    #Read user input logging level
+    log_level = getattr(logging, pytestconfig.getoption('--log'), None)
+
+    #Report invalid logging level
+    if not isinstance(log_level, int):
+        raise ValueError("Invalid log level : {}".format(log_level))
+
+    #Create basic configuration
+    logging.basicConfig(level=log_level,
+                        filename=pytestconfig.getoption('--logfile'),
+                        format='%(asctime)s - %(levelname)s ' +
+                               '- %(name)s - %(message)s')
+
+#Create a fixture to configure whether widgets are shown or not
+@pytest.fixture(scope='session', autouse=True)
+def _show_widgets(pytestconfig):
+    global show_widgets
+    show_widgets = pytestconfig.getoption('--show')
+    if show_widgets:
+        logger.info("Running tests while showing created widgets ...")
+
+@pytest.fixture(scope='module')
+def qapp():
+    global application
+    if application:
+        pass
+    else:
+        application = PyDMApplication()
+    return application
+
+def show_widget(func):
+    """
+    Show a widget returned from arbitrary `func`
+    """
+    @wraps(func)
+    def func_wrapper(*args, **kwargs):
+        #Run function grab widget
+        widget = func(*args, **kwargs)
+        if show_widgets:
+            #Display the widget
+            widget.show()
+            #Start the application
+            application.exec_()
+    return func_wrapper

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -1,0 +1,29 @@
+############
+# Standard #
+############
+
+############
+# External #
+############
+import pytest
+from ophyd.signal import EpicsSignal, EpicsSignalRO
+
+###########
+# Package #
+###########
+from typhon.panel import Panel
+from .conftest import show_widget
+
+@show_widget
+def test_panel(qapp):
+    panel = Panel(signals={
+                    #Signal is its own write            
+                    'Standard' : EpicsSignal('Tst:Pv'),
+                    #Signal has separate write/read
+                    'Read and Write' : EpicsSignal('Tst:Read',
+                                                   write_pv='Tst:Write'),
+                    #Signal is read-only
+                    'Read Only' : EpicsSignalRO('Tst:Pv:RO')},
+                  max_cols=2)
+    assert len(panel.signals) == 3
+    return panel

--- a/typhon/panel.py
+++ b/typhon/panel.py
@@ -1,0 +1,92 @@
+############
+# Standard #
+############
+import logging
+
+############
+# External #
+############
+from pydm.PyQt.QtGui import QHBoxLayout, QFont, QLabel, QWidget, QGridLayout
+from pydm.widgets.label import PyDMLabel
+from pydm.widgets.line_edit import PyDMLineEdit
+
+#############
+#  Package  #
+#############
+from .utils import channel_name
+
+logger = logging.getLogger(__name__)
+
+class Panel(QWidget):
+    """
+    Base Panel Display for Signals
+
+    Parameters
+    ----------
+    signals : OrderedDict, optional
+        Signals to include in the panel
+
+    max_cols : int, optional
+        Number of columns of information to display
+
+    parent : QWidget, optional
+        Parent of panel
+    """
+    def __init__(self, signals=None, max_cols=8, parent=None):
+        super().__init__(parent=parent)
+        self.max_cols = max_cols
+        self.signals  = dict()
+        self.layout   = QGridLayout(self)
+        #Add supplied signals
+        if signals:
+            for name, sig in signals.items():
+                self.add_signal(sig, name)
+
+    @property
+    def current_column(self):
+        """
+        Current row of panel to add widgets
+        """
+        return 2*(len(self.signals)%self.max_cols)
+
+    @property
+    def current_row(self):
+        """
+        Current column of panels to add widgets
+        """
+        return len(self.signals) // self.max_cols
+
+    def add_signal(self, signal, name):
+        """
+        Parameters
+        ----------
+        signal : EpicsSignal, EpicsSignalRO
+            Signal to create a widget
+
+        name : str
+            Name of signal to display
+        """
+        logger.info("Adding signal %r with label %s", signal, name)
+        #Create label
+        label = QLabel(self)
+        label.setText(name)
+        label_font = QFont()
+        label_font.setBold(True)
+        label.setFont(label_font)
+        #Create signal display
+        val_display = QHBoxLayout(self)
+        #Add readback
+        val_display.addWidget(PyDMLabel(init_channel=channel_name(signal._read_pv),
+                                        parent=self))
+        #Add write
+        if hasattr(signal, '_write_pv'):
+            logger.debug("Adding PyDMLineEdit for %s", name)
+            val_display.addWidget(PyDMLineEdit(init_channel=channel_name(signal._write_pv),
+                                               parent=self))
+        #Add displays to panel
+        self.layout.addWidget(label, self.current_row, self.current_column)
+        self.layout.addLayout(val_display, self.current_row, self.current_column+1)
+
+        #Store signal
+        self.signals[name] = signal
+

--- a/typhon/utils.py
+++ b/typhon/utils.py
@@ -1,0 +1,20 @@
+"""
+Utility functions for typhon
+"""
+############
+# Standard #
+############
+
+############
+# External #
+############
+
+#############
+#  Package  #
+#############
+
+def channel_name(pv):
+    """
+    Create a valid PyDM channel from a PV name
+    """
+    return 'ca://' + pv.pvname


### PR DESCRIPTION
## Description
Panel takes an arbitrary set of `EpicsSignals` and adds them to a single widget each labeled with an alias. The `Panel` handles making the correct control widgets based on whether the signal is read-nly, has separate read and write pvs e.t.c

For now, the `Panel` introspects the signal to get the name of the PVs. One could imagine in the future using `PyDMPlugin` to use the `EpicsSignal` directly.

This also adds, Travis, Codecov and Landscape configurations.

## Motivation
Closes #4 
Closes #6 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`Panel` has a specific test that instantiates all three types of signals. There is also `show_widgets` decorator that optionally shows the widget created by each test.

## Where Has This Been Documented?
Sphinx docstrings for all classes and functions